### PR TITLE
Fix jedispool usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group 'br.com.moip'
-version '0.1.3'
+version '0.1.4'
 archivesBaseName = "jcurtain"
 sourceCompatibility = 1.7
 

--- a/src/main/java/br/com/moip/jcurtain/JCurtain.java
+++ b/src/main/java/br/com/moip/jcurtain/JCurtain.java
@@ -122,6 +122,8 @@ public class JCurtain {
     private boolean isOpenForUser(String feature, String user) {
         try (Jedis jedis = jedisPool.getResource()) {
             return jedis.sismember("feature:" + feature + ":users", user);
+        } catch (JedisConnectionException e) {
+            return false;
         }
     }
 
@@ -129,6 +131,8 @@ public class JCurtain {
         try (Jedis jedis = jedisPool.getResource()) {
             String featurePercentage = jedis.get("feature:" + feature + ":percentage");
             return (featurePercentage == null ? 0 : Integer.parseInt(featurePercentage));
+        } catch (JedisConnectionException e) {
+            return 0;
         }
     }
 

--- a/src/main/java/br/com/moip/jcurtain/JCurtain.java
+++ b/src/main/java/br/com/moip/jcurtain/JCurtain.java
@@ -95,8 +95,8 @@ public class JCurtain {
      * @param user     the unique identifier for the user (email, login, sequential ID etc)
      */
     public void openFeatureForUser(String feature, String user) {
-        try {
-            jedisPool.getResource().sadd("feature:"+feature+":users", user);
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.sadd("feature:"+feature+":users", user);
         } catch (JedisConnectionException e) {
             LOGGER.error("[JCurtain] Redis connection failure while adding user to feature. " +
                             "[user={},feature={}]", user, feature);
@@ -111,8 +111,7 @@ public class JCurtain {
      * @return the {@link Feature}
      */
     public Feature getFeature(String name) {
-        try {
-            Jedis jedis = jedisPool.getResource();
+        try (Jedis jedis = jedisPool.getResource()) {
             return new Feature(name, getFeaturePercentage(name), jedis.smembers("feature:" + name + ":users"));
         } catch (JedisConnectionException e) {
             LOGGER.error("[JCurtain] Redis connection failure! Returning default value NULL. featureName={}", name);
@@ -121,12 +120,16 @@ public class JCurtain {
     }
 
     private boolean isOpenForUser(String feature, String user) {
-        return jedisPool.getResource().sismember("feature:" + feature + ":users", user);
+        try (Jedis jedis = jedisPool.getResource()) {
+            return jedis.sismember("feature:" + feature + ":users", user);
+        }
     }
 
     private int getFeaturePercentage(String feature) {
-        String featurePercentage = jedisPool.getResource().get("feature:" + feature + ":percentage");
-        return (featurePercentage == null ? 0 : Integer.parseInt(featurePercentage));
+        try (Jedis jedis = jedisPool.getResource()) {
+            String featurePercentage = jedis.get("feature:" + feature + ":percentage");
+            return (featurePercentage == null ? 0 : Integer.parseInt(featurePercentage));
+        }
     }
 
     private boolean isFeatureOpen(String feature) {


### PR DESCRIPTION
Following the redispool wiki, we should use try with resources. Jedis instance will be auto-closed after the last statement. If not we should close connection after each use.

Reference:
https://github.com/xetorthio/jedis/wiki/Getting-started